### PR TITLE
Fix wrong parameter for hash digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function passphraseToKey(type, passphrase, salt)
       c.update(passphrase);
 
     c.update(salt);
-    md_buf = c.digest('buffer');
+    md_buf = c.digest();
 
     var i = 0;
     while (nkey && i < mds)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ if (util.debuglog)
   debug = util.debuglog('ssh-key-decrypt');
 else if (/\bssh-key-decrypt\b/i.test(process.env.NODE_DEBUG || ''))
   debug = function () {
-    var msg = util.format.apply(util, arguments);
+    const msg = util.format.apply(util, arguments);
     console.error('%s %s', 'SSH-KEY-DECRYPT', msg);
   };
 else
@@ -134,7 +134,7 @@ function passphraseToKey(type, passphrase, salt) {
     niv -= steps;
     i += steps;
 
-    if ((nkey == 0) && (niv == 0)) break;
+    if ((nkey === 0) && (niv === 0)) break;
   }
 
   return key;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/isaacs/ssh-key-decrypt/issues"
   },
   "devDependencies": {
-    "tap": "^1.2.0"
+    "@types/node": "^14.14.22",
+    "tap": "^14.11.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,90 +1,78 @@
-var crypto = require('crypto');
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
-var t = require('tap');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const t = require('tap');
 
-var decrypt = require('./index.js');
+const decrypt = require('./index.js');
 
 // All the fixtures should decrypt to this key
-var unenc = path.resolve(__dirname, 'fixtures', 'id_rsa_unencrypted');
-unenc = new Buffer(fs.readFileSync(unenc, 'ascii')
-    .trim()
-    .split('\n')
-    .slice(1, -1)
-    .join(''), 'base64');
+let unenc = path.resolve(__dirname, 'fixtures', 'id_rsa_unencrypted');
+unenc = new Buffer.from(fs.readFileSync(unenc, 'ascii')
+  .trim()
+  .split('\n')
+  .slice(1, -1)
+  .join(''), 'base64');
 
-var tests =
+let tests =
   [
-  'aes128',
-  'aes192',
-  'aes256',
-  'des3',
-  'des'
+    'aes128',
+    'aes192',
+    'aes256',
+    'des3',
+    'des'
   ];
 
-tests = tests.map(function(t)
-  {
+tests = tests.map(function (t) {
   return 'enc_' + t + '_asdf';
-  });
+});
 
 tests.push('unencrypted');
 
 tests.forEach(test);
 
-function test(f)
-  {
-  var file;
-  var fileData;
+function test(f) {
+  let file;
+  let fileData;
 
-  tryThis(function()
-    {
-    file = path.resolve(__dirname, 'fixtures', 'id_rsa_' + f)
+  tryThis(function () {
+    file = path.resolve(__dirname, 'fixtures', 'id_rsa_' + f);
     fileData = fs.readFileSync(file, 'ascii');
-    }, f, 'failed reading test key');
+  }, f, 'failed reading test key');
 
-  var data;
-  tryThis(function()
-    {
+  let data;
+  tryThis(function () {
     assert(data = decrypt(fileData, 'asdf'));
     assert(Buffer.isBuffer(data), 'should be buffer');
-    }, f, 'failed decryption');
+  }, f, 'failed decryption');
 
-  var hex;
-  tryThis(function()
-    {
+  let hex;
+  tryThis(function () {
     assert(hex = decrypt(fileData, 'asdf', 'hex'));
-    assert.equal(typeof hex, 'string');
-    assert.equal(hex, data.toString('hex'));
-    }, f, 'failed hex decryption');
+    assert.strictEqual(typeof hex, 'string');
+    assert.strictEqual(hex, data.toString('hex'));
+  }, f, 'failed hex decryption');
 
-  var base64;
-  tryThis(function()
-    {
+  let base64;
+  tryThis(function () {
     assert(base64 = decrypt(fileData, 'asdf', 'base64'));
-    assert.equal(typeof base64, 'string');
-    assert.equal(base64, data.toString('base64'));
-    }, f, 'failed base64 decryption');
+    assert.strictEqual(typeof base64, 'string');
+    assert.strictEqual(base64, data.toString('base64'));
+  }, f, 'failed base64 decryption');
 
-  tryThis(function()
-    {
-    assert.equal(data.length, unenc.length);
-    }, f, 'length differs');
+  tryThis(function () {
+    assert.strictEqual(data.length, unenc.length);
+  }, f, 'length differs');
 
-  tryThis(function()
-    {
-    for (var i = 0; i < data.length; i++)
-      {
-      assert.equal(data[i], unenc[i], 'differs at position ' + i);
-      }
-    }, f, 'byte check');
-  }
+  tryThis(function () {
+    for (let i = 0; i < data.length; i++) {
+      assert.strictEqual(data[i], unenc[i], 'differs at position ' + i);
+    }
+  }, f, 'byte check');
+}
 
-function tryThis(fn, f, msg)
-  {
-  t.test(f, function (t)
-    {
-    t.plan(1)
-    t.doesNotThrow(fn, msg)
-    })
-  }
+function tryThis(fn, f, msg) {
+  t.test(f, function (t) {
+    t.plan(1);
+    t.doesNotThrow(fn, msg);
+  })
+}


### PR DESCRIPTION
Hello,

I found an issue in one of my projects where I need this package to run in the browser. 
The `digest()` function was not called with the correct parameter and it generates an exception. Also, I found that it only worked correctly when no parameter is supplied to the function.

Tests are not affected by the change. When running on back-end there was no difference with or without the parameter.

Regards,
Nate